### PR TITLE
Use bindeb-pkg instead of deb-pkg

### DIFF
--- a/doc/PreemptRt.md
+++ b/doc/PreemptRt.md
@@ -250,7 +250,7 @@ Now it is time to build the kernel:
   ```shell
   $ make clean # Optional to remove old relicts (from previously failed compilations)
   # The following command might take very long!
-  $ sudo make -j$(nproc) deb-pkg
+  $ sudo make -j$(nproc) bindeb-pkg
   ```
   
   where the [`revision` parameter is just for keeping track of the version number of your kernel builds](https://www.debian.org/releases/wheezy/amd64/ch08s06.html.en) and can be changed at will, similarly for the `custom` word.

--- a/src/lib_compile_kernel.sh
+++ b/src/lib_compile_kernel.sh
@@ -219,7 +219,7 @@ function select_installation_mode() {
 
 function generate_preemptrt_kernel_debian_package() {
   declare desc="Generate Debian package for easier installation and uninstallation"
-  sudo make -j$(nproc) deb-pkg
+  sudo make -j$(nproc) bindeb-pkg
 }
 
 function select_install_now() {


### PR DESCRIPTION
Thank you for the detailed documentation and scripts. I encountered an issue while building kernel 6.8.2-rt11 on Ubuntu 24 with kernel version 6.8.0. The error was: "creating source package requires git repository", same as described [here](https://askubuntu.com/questions/1465295/kernel-6-3-custom-compile-error).

To resolve this, I switched from deb-pkg to bindeb-pkg, and the build worked successfully. Additionally, I noticed that the kernel-package package is no longer available (it shows "no installation candidate"). Instead, I had to install debhelper-compat (sudo apt install debhelper-compat) to fulfill the build dependencies.